### PR TITLE
Added new "PeerMenuCreateEvent" method in "window_peer_menu.cpp"

### DIFF
--- a/Telegram/SourceFiles/window/window_peer_menu.cpp
+++ b/Telegram/SourceFiles/window/window_peer_menu.cpp
@@ -1195,7 +1195,7 @@ void Filler::addCreateEvent() {
 	const auto flag = PollData::Flags();
 	const auto replyTo = _request.currentReplyTo;
 	auto callback = [=] {
-		PeerMenuCreatePoll( // should call `PeerMenuCreateEvent`
+		PeerMenuCreateEvent( // should call `PeerMenuCreateEvent`
 			controller,
 			peer,
 			replyTo,
@@ -1691,8 +1691,7 @@ void PeerMenuCreatePoll(
 	controller->show(std::move(box), Ui::LayerOption::CloseOther);
 }
 
-// Uncomment once CreateEventBox is complete 
-/*
+// Uncomment once CreateEventBox is complete
 void PeerMenuCreateEvent(
         not_null<Window::SessionController*> controller,
         not_null<PeerData*> peer,
@@ -1738,7 +1737,6 @@ void PeerMenuCreateEvent(
     }, box->lifetime());
     controller->show(std::move(box), Ui::LayerOption::CloseOther);
 }
-*/
 
 void PeerMenuBlockUserBox(
 		not_null<Ui::GenericBox*> box,

--- a/Telegram/SourceFiles/window/window_peer_menu.cpp
+++ b/Telegram/SourceFiles/window/window_peer_menu.cpp
@@ -1691,8 +1691,54 @@ void PeerMenuCreatePoll(
 	controller->show(std::move(box), Ui::LayerOption::CloseOther);
 }
 
-// TODO. See above PeerMenuCreatePoll function for reference.
-void PeerMenuCreateEvent() {}
+// Uncomment once CreateEventBox is complete 
+/*
+void PeerMenuCreateEvent(
+        not_null<Window::SessionController*> controller,
+        not_null<PeerData*> peer,
+        FullReplyTo replyTo,
+        PollData::Flags chosen,
+        PollData::Flags disabled,
+        Api::SendType sendType,
+        SendMenu::Type sendMenuType) {
+    if (peer->isChannel() && !peer->isMegagroup()) {
+        chosen &= ~PollData::Flag::PublicVotes;
+        disabled |= PollData::Flag::PublicVotes;
+    }
+    auto box = Box<CreateEventBox>(
+        controller,
+        chosen,
+        disabled,
+        sendType,
+        sendMenuType);
+    const auto weak = Ui::MakeWeak(box.data());
+    const auto lock = box->lifetime().make_state<bool>(false);
+    box->submitRequests(
+    ) | rpl::start_with_next([=](const CreateEventBox::Result &result) {
+        if (std::exchange(*lock, true)) {
+            return;
+        }
+        auto action = Api::SendAction(
+            peer->owner().history(peer),
+            result.options);
+        action.replyTo = replyTo;
+        const auto topicRootId = replyTo.topicRootId;
+        if (const auto local = action.history->localDraft(topicRootId)) {
+            action.clearDraft = local->textWithTags.text.isEmpty();
+        } else {
+            action.clearDraft = false;
+        }
+        const auto api = &peer->session().api();
+        api->polls().create(result.poll, action, crl::guard(weak, [=] {
+            weak->closeBox();
+        }), crl::guard(weak, [=] {
+            *lock = false;
+            weak->submitFailed(tr::lng_attach_failed(tr::now));
+        }));
+    }, box->lifetime());
+    controller->show(std::move(box), Ui::LayerOption::CloseOther);
+}
+*/
 
 void PeerMenuBlockUserBox(
 		not_null<Ui::GenericBox*> box,


### PR DESCRIPTION
When we click on "Create event" it will eventually call the "PeerMenuCreateEvent" function in "window_peer_menu.cpp". I updated the function to use "CreateEventBox" but the new function will depend on "create_event_box.h" and "create_event_box.cpp" being implemented. 